### PR TITLE
fix: support woke.yml files as well

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -19,7 +19,9 @@ plugs:
     interface: personal-files
     read:
       - $HOME/.config/woke.yaml
+      - $HOME/.config/woke.yml
       - $HOME/.woke.yaml
+      - $HOME/.woke.yml
 
 apps:
   woke:


### PR DESCRIPTION
Woke supports both `woke.yaml` and `woke.yml`, ensure both can be read. Reference: https://docs.getwoke.tech/usage/#config-file